### PR TITLE
Rename to the os2display namespace.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "itk-os2display/youtube-bundle",
+    "name": "os2display/youtube-bundle",
     "description": "Os2Display youtube template.",
     "type": "symfony-bundle",
     "require": {


### PR DESCRIPTION
To be in the same namespace as fx. vimeo-bundle.